### PR TITLE
rename bigquery_dataset to bq_dataset for consistency with other resource names.

### DIFF
--- a/deploy/cft/cft.go
+++ b/deploy/cft/cft.go
@@ -85,7 +85,7 @@ type Project struct {
 
 // BigqueryDatasetPair pairs a raw dataset with its parsed version.
 type BigqueryDatasetPair struct {
-	Raw    json.RawMessage `json:"bigquery_dataset"`
+	Raw    json.RawMessage `json:"bq_dataset"`
 	Parsed BigqueryDataset `json:"-"`
 }
 

--- a/deploy/cft/cft_test.go
+++ b/deploy/cft/cft_test.go
@@ -94,10 +94,10 @@ func TestDeploy(t *testing.T) {
 		want       string
 	}{
 		{
-			name: "bigquery_dataset",
+			name: "bq_dataset",
 			configData: &ConfigData{`
 resources:
-- bigquery_dataset:
+- bq_dataset:
     properties:
       name: foo-dataset
       location: US`},

--- a/deploy/project_config.yaml.schema
+++ b/deploy/project_config.yaml.schema
@@ -470,7 +470,7 @@ definitions:
           type: object
           additionalProperties: false
           properties:
-            bigquery_dataset:
+            bq_dataset:
               type: object
               description: Provides support for BigQuery Datasets.
               additionalProperties: false

--- a/deploy/rulegen/bigquery_test.go
+++ b/deploy/rulegen/bigquery_test.go
@@ -54,11 +54,11 @@ func TestBigqueryRules(t *testing.T) {
 			name: "dataset",
 			configData: &ConfigData{`
 resources:
-- bigquery_dataset:
+- bq_dataset:
     properties:
       name: foo-dataset
       location: US
-- bigquery_dataset:
+- bq_dataset:
     properties:
       name: bar-dataset
       location: US`},

--- a/deploy/rulegen/location_test.go
+++ b/deploy/rulegen/location_test.go
@@ -9,7 +9,7 @@ import (
 
 var locConfigData = &ConfigData{`
 resources:
-- bigquery_dataset:
+- bq_dataset:
     properties:
       name: foo-dataset
       location: US

--- a/deploy/rulegen/resource_test.go
+++ b/deploy/rulegen/resource_test.go
@@ -10,7 +10,7 @@ import (
 func TestResourceRules(t *testing.T) {
 	configData := &ConfigData{`
 resources:
-- bigquery_dataset:
+- bq_dataset:
     properties:
       name: foo-dataset
       location: US


### PR DESCRIPTION
rename bigquery_dataset to bq_dataset for consistency with other resource names.