### PR TITLE
Do not add "-cluster" after the GKE clusters' names any more.

### DIFF
--- a/deploy/apply/gke.go
+++ b/deploy/apply/gke.go
@@ -56,7 +56,7 @@ func installClusterWorkloadFromFile(clusterName, containerYamlPath string, proje
 	if err != nil {
 		return err
 	}
-	if err := getGCloudCredentials(clusterName+"-cluster", locationType, locationValue, project.ID); err != nil {
+	if err := getGCloudCredentials(clusterName, locationType, locationValue, project.ID); err != nil {
 		return err
 	}
 	if err := applyClusterWorkload(containerYamlPath); err != nil {

--- a/deploy/apply/gke_test.go
+++ b/deploy/apply/gke_test.go
@@ -103,7 +103,7 @@ resources:
 	}
 
 	wantArgs := [][]string{
-		{"gcloud", "container", "clusters", "get-credentials", "cluster1-cluster", "--region", "somewhere1", "--project", "my-project"},
+		{"gcloud", "container", "clusters", "get-credentials", "cluster1", "--region", "somewhere1", "--project", "my-project"},
 		{"kubectl", "apply", "-f"},
 	}
 


### PR DESCRIPTION
Do not add "-cluster" after the GKE clusters' names any more.