### PR TITLE
Use safe_substitute instead of substitute to replace environment variables.

### DIFF
--- a/deploy/utils/utils.py
+++ b/deploy/utils/utils.py
@@ -339,7 +339,7 @@ def resolve_env_vars(config):
     # Only do substitutions on strings.
     v = config[k]
     if isinstance(v, str):
-      config[k] = string.Template(v).substitute(os.environ)
+      config[k] = string.Template(v).safe_substitute(os.environ)
     else:
       # Recursively handle lists and dictionaries.
       resolve_env_vars(v)


### PR DESCRIPTION
Use safe_substitute instead of substitute to replace environment variables.