### PR TITLE
move generated_fields_path higher up in the config schema, minor wording change, don't make intermediate dirs

### DIFF
--- a/deploy/config/load.go
+++ b/deploy/config/load.go
@@ -292,10 +292,6 @@ func patternPaths(projectYAMLPath string, importsList []*importsItem) ([]string,
 
 // loadGeneratedFields loads and validates generated fields from yaml file at path.
 func loadGeneratedFields(path string) (*AllGeneratedFields, error) {
-	// Create an empty file (and parent directories, if any) if not exist.
-	if err := os.MkdirAll(filepath.Dir(path), os.ModePerm); err != nil {
-		return nil, fmt.Errorf("failed to create directory: %v", err)
-	}
 	if _, err := os.OpenFile(path, os.O_RDONLY|os.O_CREATE, 0666); err != nil {
 		return nil, fmt.Errorf("failed to create an empty generated fields file: %v\nnote: if you hit this error in a test, please create an empty generated fields file manually and add it as a test dependency", err)
 	}

--- a/deploy/config/load_test.go
+++ b/deploy/config/load_test.go
@@ -141,7 +141,7 @@ func TestLoadGeneratedFields(t *testing.T) {
 			inputConf: []byte(`
 overall:
   billing_account: 000000-000000-000000
-generated_fields_path: a/b/c/generated_fields.yaml
+generated_fields_path: ./generated_fields.yaml
 projects: []
 `),
 			wantErr: false,
@@ -161,6 +161,16 @@ projects: []
 overall:
   billing_account: 000000-000000-000000
 generated_fields_path: /a/b/c/generated_fields.yaml
+projects: []
+`),
+			wantErr: true,
+		},
+		{
+			name: "missing_intermediate_dirs",
+			inputConf: []byte(`
+overall:
+  billing_account: 000000-000000-000000
+generated_fields_path: dne/generated_fields.yaml
 projects: []
 `),
 			wantErr: true,

--- a/deploy/project_config.yaml.schema
+++ b/deploy/project_config.yaml.schema
@@ -934,6 +934,13 @@ properties:
           type: string
           minLength: 2
 
+  generated_fields_path:
+    type: string
+    description: |
+      The path of file to store information generated during the deployment
+      process, such as project numbers and Forseti service account. Must be
+      relative to the directory of the config file containing this field.
+
   devops:
     type: object
     description: The devops configuration.
@@ -1010,10 +1017,3 @@ properties:
           type: string
           description: |
             Glob supported as defined in https://godoc.org/path/filepath#Glob.
-
-  generated_fields_path:
-    type: string
-    description: |
-      The path of file to store information generated during the deployment
-      process, such as project numbers and Forseti service account. Must be
-      relative to the directory holding the project config.


### PR DESCRIPTION
move generated_fields_path higher up in the config schema, minor wording change, don't make intermediate dirs