### PR TITLE
rename terraform block in project to devops for consistency with top level devops config

### DIFF
--- a/deploy/apply/forseti.go
+++ b/deploy/apply/forseti.go
@@ -92,7 +92,7 @@ func forsetiConfig(conf *config.Config) error {
 	}}
 
 	tfConf.Terraform.Backend = &terraform.Backend{
-		Bucket: conf.Forseti.Project.TerraformConfig.StateBucket.Name,
+		Bucket: conf.Forseti.Project.DevopsConfig.StateBucket.Name,
 		Prefix: "forseti",
 	}
 
@@ -115,16 +115,16 @@ func forsetiConfig(conf *config.Config) error {
 }
 
 func stateBucket(project *config.Project) error {
-	if project.TerraformConfig.StateBucket == nil {
+	if project.DevopsConfig.StateBucket == nil {
 		return errors.New("state_storage_bucket must not be nil")
 	}
 
 	tfConf := terraform.NewConfig()
-	if err := addResources(tfConf, project.TerraformConfig.StateBucket); err != nil {
+	if err := addResources(tfConf, project.DevopsConfig.StateBucket); err != nil {
 		return err
 	}
 	opts := &terraform.Options{}
-	if err := addImports(opts, project.TerraformConfig.StateBucket); err != nil {
+	if err := addImports(opts, project.DevopsConfig.StateBucket); err != nil {
 		return err
 	}
 

--- a/deploy/apply/terraform.go
+++ b/deploy/apply/terraform.go
@@ -168,12 +168,12 @@ func createProjectTerraform(config *config.Config, project *config.Project) erro
 	}
 
 	tfConf := terraform.NewConfig()
-	if err := addResources(tfConf, pr, project.TerraformConfig.StateBucket); err != nil {
+	if err := addResources(tfConf, pr, project.DevopsConfig.StateBucket); err != nil {
 		return err
 	}
 	opts := &terraform.Options{}
 	// Since the project creation deployment is not linked to a remote state, always import the project and state bucket.
-	if err := addImports(opts, pr, project.TerraformConfig.StateBucket); err != nil {
+	if err := addImports(opts, pr, project.DevopsConfig.StateBucket); err != nil {
 		return err
 	}
 
@@ -209,7 +209,7 @@ func defaultTerraform(config *config.Config, project *config.Project, opts *Opti
 func services(project *config.Project) error {
 	tfConf := terraform.NewConfig()
 	tfConf.Terraform.Backend = &terraform.Backend{
-		Bucket: project.TerraformConfig.StateBucket.Name,
+		Bucket: project.DevopsConfig.StateBucket.Name,
 		Prefix: "services",
 	}
 
@@ -234,7 +234,7 @@ func auditResources(config *config.Config, project *config.Project, opts *Option
 	auditProject := config.ProjectForAuditLogs(project)
 	tfConf := terraform.NewConfig()
 	tfConf.Terraform.Backend = &terraform.Backend{
-		Bucket: auditProject.TerraformConfig.StateBucket.Name,
+		Bucket: auditProject.DevopsConfig.StateBucket.Name,
 		// Attach project ID to prefix.
 		// This is because the audit project will contain an audit deployment for every project it holds audit logs for in its own state bucket.
 		// Attaching the prefix ensures we don't have a collision in names.
@@ -304,7 +304,7 @@ func resources(project *config.Project, opts *Options) error {
 	)
 
 	tfConf.Terraform.Backend = &terraform.Backend{
-		Bucket: project.TerraformConfig.StateBucket.Name,
+		Bucket: project.DevopsConfig.StateBucket.Name,
 		Prefix: "resources",
 	}
 

--- a/deploy/config/config.go
+++ b/deploy/config/config.go
@@ -76,9 +76,9 @@ type Project struct {
 	DataReadWriteGroups []string `json:"data_readwrite_groups"`
 	DataReadOnlyGroups  []string `json:"data_readonly_groups"`
 
-	TerraformConfig struct {
+	DevopsConfig struct {
 		StateBucket *tfconfig.StorageBucket `json:"state_storage_bucket"`
-	} `json:"terraform"`
+	} `json:"devops"`
 
 	CreateDeletionLien    bool                `json:"create_deletion_lien"`
 	EnabledAPIs           []string            `json:"enabled_apis"`
@@ -289,14 +289,14 @@ func (p *Project) Init(devopsProject, auditLogsProject *Project) error {
 
 	// init the state bucket outside the regular terraform resoures since forseti projects will
 	// still define a state bucket even when not enabling terraform.
-	if sb := p.TerraformConfig.StateBucket; sb != nil {
+	if sb := p.DevopsConfig.StateBucket; sb != nil {
 		if err := sb.Init(devopsProject.ID); err != nil {
 			return fmt.Errorf("failed to init terraform state bucket: %v", err)
 		}
 	}
 
 	if EnableTerraform {
-		sb := p.TerraformConfig.StateBucket
+		sb := p.DevopsConfig.StateBucket
 		if sb == nil {
 			return errors.New("state_storage_bucket must be set when terraform is enabled")
 		}

--- a/deploy/project_config.yaml.schema
+++ b/deploy/project_config.yaml.schema
@@ -92,9 +92,9 @@ definitions:
         items:
           $ref: '#/definitions/email_address'
 
-      terraform:
+      devops:
         type: object
-        description: DEV ONLY. Configuration for Terraform.
+        description: DEV ONLY. Configuration for devops related components like Terraform.
         additionalProperties: false
         required:
         - state_storage_bucket
@@ -102,7 +102,8 @@ definitions:
           state_storage_bucket:
             type: object
             description: |
-              Bucket for Teraform to store its remote state.
+              Bucket for Teraform to store its remote state
+              (https://www.terraform.io/docs/state/remote.html).
               Wraps https://www.terraform.io/docs/providers/google/r/storage_bucket.html.
 
       create_deletion_lien:

--- a/deploy/samples/project_with_local_audit_logs.yaml
+++ b/deploy/samples/project_with_local_audit_logs.yaml
@@ -37,7 +37,7 @@ forseti:
     owners_group: my-forseti-project-owners@mydomain.com    # Replace this with the owners group for this project.
     auditors_group: my-forseti-project-auditors@mydomain.com  # Replace this with your auditors group.
     create_deletion_lien: true
-    terraform:
+    devops:
       state_storage_bucket:
         name: my-forseti-project-state
         location: US

--- a/deploy/samples/project_with_remote_audit_logs.yaml
+++ b/deploy/samples/project_with_remote_audit_logs.yaml
@@ -51,7 +51,7 @@ forseti:
     owners_group: my-forseti-project-owners@mydomain.com    # Replace this with the owners group for this project.
     auditors_group: my-forseti-project-auditors@mydomain.com  # Replace this with your auditors group.
     create_deletion_lien: true
-    terraform:
+    devops:
       state_storage_bucket:
         name: my-forseti-project-state
         location: US

--- a/deploy/samples/spanned_configs/projects/partial_audit.yaml
+++ b/deploy/samples/spanned_configs/projects/partial_audit.yaml
@@ -39,7 +39,7 @@ forseti:
     owners_group: my-forseti-project-owners@mydomain.com    # Replace this with the owners group for this project.
     auditors_group: my-forseti-project-auditors@mydomain.com  # Replace this with your auditors group.
     create_deletion_lien: true
-    terraform:
+    devops:
       state_storage_bucket:
         name: my-forseti-project-state
         location: US

--- a/deploy/samples/terraform.yaml
+++ b/deploy/samples/terraform.yaml
@@ -15,7 +15,7 @@ devops:
       logs_bigquery_dataset:
         dataset_id: devops_audit_logs
         location: US
-    terraform:
+    devops:
       state_storage_bucket:
         name: foo-devops-state
         location: US
@@ -28,7 +28,7 @@ audit_logs_project:
     logs_bigquery_dataset:
       dataset_id: foo_audit_logs
       location: US
-  terraform:
+  devops:
     state_storage_bucket:
       name: foo-audit-state
       location: US
@@ -42,7 +42,7 @@ forseti:
       logs_bigquery_dataset:
         dataset_id: foo_forseti_logs
         location: US
-    terraform:
+    devops:
       state_storage_bucket:
         name: foo-forseti-state
         location: US
@@ -57,7 +57,7 @@ projects:
     logs_bigquery_dataset:
       dataset_id: data_audit_logs
       location: US
-  terraform:
+  devops:
     state_storage_bucket:
       name: foo-data-state
       location: US

--- a/deploy/testconf/testconf.go
+++ b/deploy/testconf/testconf.go
@@ -43,7 +43,7 @@ forseti:
     project_id: my-forseti-project
     owners_group: my-forseti-project-owners@my-domain.com
     auditors_group: my-forseti-project-auditors@my-domain.com
-    terraform:
+    devops:
       state_storage_bucket:
         name: my-forseti-project-state
         location: US
@@ -78,7 +78,7 @@ projects:
   data_readonly_groups:
   - my-project-readonly@my-domain.com
   - another-readonly-group@googlegroups.com
-  terraform:
+  devops:
     state_storage_bucket:
       name: my-project-state
       location: US


### PR DESCRIPTION
rename terraform block in project to devops for consistency with top level devops config