### PR TITLE
make custom teraform configs more flexible

### DIFF
--- a/deploy/config/config.go
+++ b/deploy/config/config.go
@@ -24,7 +24,6 @@ import (
 	"text/template"
 
 	"github.com/GoogleCloudPlatform/healthcare/deploy/config/tfconfig"
-	"github.com/GoogleCloudPlatform/healthcare/deploy/terraform"
 )
 
 // EnableTerraform determines whether terraform will be enabled or not.
@@ -135,7 +134,11 @@ type Project struct {
 		LogsStorageBucket   *tfconfig.StorageBucket   `json:"logs_storage_bucket"`
 	} `json:"audit"`
 
-	ResourcesDeployment *terraform.Config `json:"resources_deployment"`
+	TerraformDeployments struct {
+		Resources struct {
+			Config map[string]interface{} `json:"config"`
+		} `json:"resources"`
+	} `json:"terraform_deployments"`
 
 	// The following vars are set through helpers and not directly through the user defined config.
 	GeneratedFields *GeneratedFields `json:"-"`

--- a/deploy/project_config.yaml.schema
+++ b/deploy/project_config.yaml.schema
@@ -782,41 +782,29 @@ definitions:
                           description:
                             Identities that will be granted the privilege in role.
 
-      resources_deployment:
+      terraform_deployments:
         type: object
         description: |
           TERRAFORM ONLY.
-          Configure the 'resources' deployment. Useful for adding resources that
-          are not natively supported by the toolkit.
+          Configure the terraform deployments in this project.
+          Useful for customizing the deployment to output values or add
+          unsupported resources/modules.
+          Currently, only the 'resources' deployment can be configured.
+          Any Terraform JSON syntax is supported:
+          https://www.terraform.io/docs/configuration/syntax-json.html.
           NOTE: This is an advanced feature and should be avoided if possible.
-          If the resources being configured here can be supported natively,
-          please reach out to the team and prefer to use that.
+          If the custom config can be supported natively, please reach out to
+          the team and prefer to use that.
         additionalProperties: false
         properties:
-          resource:
-            type: array
-            description: Additional terraform resources to deploy.
+          resources:
+            type: object
+            description: Customization for the resources deployment.
             additionalProperties: false
-            required:
-            - name
-            - type
-            - properties
             properties:
-              name:
-                type: string
-                description: |
-                  Terraform resource name. This should be unique among all
-                  resources of this type.
-              type:
-                type: string
-                description: |
-                  Terraform resource type.
-                  Supports any resource in https://www.terraform.io/docs/providers/google/index.html.
-              properties:
+              config:
                 type: object
-                description: |
-                  Terraform resource fields. All required fields should be
-                  set. The toolkit will not set any defaults or add any checks.
+                description: Additional config to attach to this deployment.
 
       resource_manager_liens:
         type: array

--- a/deploy/terraform/BUILD
+++ b/deploy/terraform/BUILD
@@ -1,8 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
-
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -13,6 +13,7 @@ go_library(
     importpath = "github.com/GoogleCloudPlatform/healthcare/deploy/terraform",
     deps = [
         "//runner:go_default_library",
+        "@com_github_imdario_mergo//:go_default_library",
     ],
 )
 

--- a/deploy/terraform/apply_test.go
+++ b/deploy/terraform/apply_test.go
@@ -63,13 +63,29 @@ func TestApply(t *testing.T) {
 		Source:     "foo-source",
 		Properties: map[string]interface{}{"prop2": "val2"},
 	}}
+
+	opts := &Options{}
+
+	customJSON := []byte(`{
+  "resource": [{
+     "custom_type": {
+		   "custom-name": {
+         "name": "custom-name",
+         "project": "my-project"
+			 }
+     }
+  }]
+}`)
+	if err := json.Unmarshal(customJSON, &opts.CustomConfig); err != nil {
+		t.Fatalf("json.Unmarshal custom JSON: %v", err)
+	}
 	dir, err := ioutil.TempDir("", "")
 	if err != nil {
 		t.Fatalf("ioutil.TempDir: %v", err)
 	}
 	defer os.RemoveAll(dir)
 	r := &testRunner{}
-	if err := Apply(conf, dir, nil, r); err != nil {
+	if err := Apply(conf, dir, opts, r); err != nil {
 		t.Fatalf("Forseti = %v", err)
 	}
 
@@ -83,13 +99,23 @@ func TestApply(t *testing.T) {
 			}
 		}
 	},
-	"resource": [{
-		"foo-type": {
-			"foo-resource": {
-				"prop1": "val1"
-			}
-		}
-	}],
+	"resource": [
+    {
+		  "foo-type": {
+		  	"foo-resource": {
+		  		"prop1": "val1"
+	  		}
+	  	}
+	  },
+    {
+      "custom_type": {
+        "custom-name": {
+          "name": "custom-name",
+          "project": "my-project"
+        }
+      }
+    }
+  ],
 	"module": [{
 		"foo-module": {
 			 "source": "foo-source",


### PR DESCRIPTION
make custom teraform configs more flexible

The following changes are made:
- resources_deployment is renamed to terraform_deployments
- Allow multiple deployments to be referenced (initially only resources supported)
- Within a deployment, allow multiple fields to be configured (currently only 'config' can be configured).
- Merge the config with the final config, and not parse into our intermediate form. This allows the user to use the official terraform JSON config style and also set any field without needing to understand our middle layer or wait for support from us.