### PR TITLE
Always copy Terraform modules to running dir, even in dryrun.

### DIFF
--- a/deploy/cmd/apply/testdata/project_with_remote_audit_logs_dryrun_commands.txt
+++ b/deploy/cmd/apply/testdata/project_with_remote_audit_logs_dryrun_commands.txt
@@ -24,7 +24,6 @@ gcloud --project my-forseti-project alpha monitoring policies create --policy={"
 terraform init
 terraform import -no-color google_storage_bucket.my-forseti-project-state my-forseti-project/my-forseti-project-state
 terraform apply
-cp -r ./external/terraform_google_forseti /tmp/xxxxxxxxx
 terraform init
 terraform apply
 gcloud --project my-forseti-project iam service-accounts list --format json --filter email:forseti-server-gcp-*

--- a/deploy/runner/runner.go
+++ b/deploy/runner/runner.go
@@ -80,14 +80,23 @@ type Fake struct{}
 
 // CmdRun prints the command information.
 func (*Fake) CmdRun(cmd *exec.Cmd) error {
-	log.Printf("Dry run call: %s", strings.Join(cmd.Args, " "))
-	return nil
+	cmdStr := strings.Join(cmd.Args, " ")
+	switch {
+	case contains(cmdStr, "cp"):
+		// In dry_run mode, stil execute commands that copy Terraform modules and configs
+		// to the Terraform working directory so that users can find them.
+		return (&Default{}).CmdRun(cmd)
+	default:
+		log.Printf("Dry run call: %s", strings.Join(cmd.Args, " "))
+		return nil
+	}
 }
 
 // CmdOutput prints the command information.
 func (*Fake) CmdOutput(cmd *exec.Cmd) ([]byte, error) {
 	log.Printf("Dry run call: %s", strings.Join(cmd.Args, " "))
-	switch cmdStr := strings.Join(cmd.Args, " "); {
+	cmdStr := strings.Join(cmd.Args, " ")
+	switch {
 	case contains(cmdStr, "projects describe"):
 		return nil, errors.New("")
 	case contains(cmdStr, "logging sinks describe audit-logs-to-bigquery", "--format json"):
@@ -118,7 +127,8 @@ func (*Fake) CmdOutput(cmd *exec.Cmd) ([]byte, error) {
 // CmdCombinedOutput prints the command information.
 func (*Fake) CmdCombinedOutput(cmd *exec.Cmd) ([]byte, error) {
 	log.Printf("Dry run call: %s", strings.Join(cmd.Args, " "))
-	switch cmdStr := strings.Join(cmd.Args, " "); {
+	cmdStr := strings.Join(cmd.Args, " ")
+	switch {
 	case contains(cmdStr, "deployment-manager deployments list", "--format json"):
 		return []byte("[]"), nil
 	case contains(cmdStr, "monitoring policies list"):

--- a/deploy/terraform/apply.go
+++ b/deploy/terraform/apply.go
@@ -57,7 +57,7 @@ func Apply(config *Config, dir string, opts *Options, rn runner.Runner) error {
 		if err := os.MkdirAll(dst, os.ModePerm); err != nil {
 			return fmt.Errorf("failed to mkdir %q: %v", dst, err)
 		}
-		if err := rn.CmdRun(exec.Command("cp", "-r", m.Source, dst)); err != nil {
+		if err := rn.CmdRun(exec.Command("cp", "-r", "-L", "--no-preserve=mode,ownership", m.Source, dst)); err != nil {
 			return fmt.Errorf("failed to copy %q to %q: %v", m.Source, dst, err)
 		}
 	}


### PR DESCRIPTION
Always copy Terraform modules to running dir, even in dryrun.