### PR TITLE
stop requiring projects to be set

### DIFF
--- a/deploy/config/load_test.go
+++ b/deploy/config/load_test.go
@@ -63,7 +63,6 @@ projects: []
 			inputConf: []byte(`
 generated_fields_path: bar.yaml
 overall:
-  billing_account: 000000-000000-000000
   organization_id: '12345678'
   domain: foo.com
 `),

--- a/deploy/project_config.yaml.schema
+++ b/deploy/project_config.yaml.schema
@@ -906,7 +906,6 @@ definitions:
                     Identities that will be granted the privilege in role.
 required:
 - overall
-- projects
 - generated_fields_path
 
 properties:


### PR DESCRIPTION
stop requiring projects to be set