### PR TITLE
rename data project ID resource to 'project' for consistency

### DIFF
--- a/deploy/apply/terraform.go
+++ b/deploy/apply/terraform.go
@@ -333,7 +333,7 @@ func resources(project *config.Project, opts *Options, workDir string, rn runner
 
 	// Allow user resources to access project runtime info such as project number.
 	tfConf.Data = []*terraform.Resource{{
-		Name: project.ID,
+		Name: "project",
 		Type: "google_project",
 		Properties: map[string]interface{}{
 			"project_id": project.ID,

--- a/deploy/apply/terraform_test.go
+++ b/deploy/apply/terraform_test.go
@@ -49,7 +49,7 @@ terraform:
       prefix: resources
 data:
 - google_project:
-    my-project:
+    project:
       project_id: my-project
 resource:
 - google_project_iam_audit_config:


### PR DESCRIPTION
rename data project ID resource to 'project' for consistency