### PR TITLE
Refactor test dependencies to make dependency on terraform_google_forseti explicit.

### DIFF
--- a/deploy/samples/deployment_manager/BUILD
+++ b/deploy/samples/deployment_manager/BUILD
@@ -13,11 +13,17 @@ config_test(
 config_test(
     name = "sample_project_with_local_audit_logs_config_test",
     config = ":project_with_local_audit_logs.yaml",
-    deps = [":generated_fields.yaml"],
+    deps = [
+        ":generated_fields.yaml",
+        "//external/terraform_google_forseti:forseti",
+    ],
 )
 
 config_test(
     name = "sample_project_with_remote_audit_logs_config_test",
     config = ":project_with_remote_audit_logs.yaml",
-    deps = [":generated_fields.yaml"],
+    deps = [
+        ":generated_fields.yaml",
+        "//external/terraform_google_forseti:forseti",
+    ],
 )

--- a/deploy/samples/environments/BUILD
+++ b/deploy/samples/environments/BUILD
@@ -13,6 +13,7 @@ licenses(["notice"])
             ":generated_fields.yaml",
             ":overall.yaml",
             ":project.tmpl.yaml",
+            "//external/terraform_google_forseti:forseti",
         ],
     )
     for env in [

--- a/deploy/samples/full/BUILD
+++ b/deploy/samples/full/BUILD
@@ -9,6 +9,7 @@ filegroup(
     srcs = [
         ":generated_fields.yaml",
         ":shared.yaml",
+        "//external/terraform_google_forseti:forseti",
     ],
 )
 
@@ -26,5 +27,8 @@ config_test(
     name = "shared_config_test",
     config = ":shared.yaml",
     enable_terraform = True,
-    deps = [":generated_fields.yaml"],
+    deps = [
+        ":generated_fields.yaml",
+        "//external/terraform_google_forseti:forseti",
+    ],
 )

--- a/deploy/starlark/config_test.bzl
+++ b/deploy/starlark/config_test.bzl
@@ -27,7 +27,7 @@ def _impl(ctx):
         ctx.file._generated_fields_schema,
         ctx.file._project_config_schema,
         ctx.file.config,
-    ] + ctx.files.deps + ctx.files._terraform_google_forseti
+    ] + ctx.files.deps
 
     return [DefaultInfo(runfiles = ctx.runfiles(files = runfiles))]
 
@@ -56,11 +56,6 @@ _config_test = rule(
             cfg = "host",
             executable = True,
             allow_single_file = True,
-        ),
-        "_terraform_google_forseti": attr.label(
-            default = Label("//external/terraform_google_forseti:forseti"),
-            doc = "The generated fields schema. Internal attribute and should not be set by users.",
-            cfg = "host",
         ),
         # The following attributes are added purely for the purpose of making
         # schema files available in the runfiles tree.


### PR DESCRIPTION
Refactor test dependencies to make dependency on terraform_google_forseti explicit.
