### PR TITLE
[#433] switch from gcs storage to hcapi hosted data

### DIFF
--- a/imaging/ml/ml_codelab/README.md
+++ b/imaging/ml/ml_codelab/README.md
@@ -8,6 +8,10 @@ We first need to enable the AI Platform Notebooks. Follow the steps listed [here
 
 ## Set-up permissions
 
+Go to https://cloud.google.com/healthcare/docs/resources/public-datasets/tcia#cloud-healthcare-api to request permissions to tcia dataset.
+
+**Please wait until you are granted access.** You cannot complete the codelab until granted access.
+
 We need to allow the service account running the AI Platform Notebooks instance to administer Pubsub changes. The codelabs utilize Cloud Pubsub as a notification mechanism. Enter your project ID below and execute the following:
 
 ```shell
@@ -24,7 +28,20 @@ Follow the steps listed [here](https://cloud.google.com/ai-platform/notebooks/do
 
 ## Create a new Notebook instance
 
-Click "OPEN JUPYTERLAB", in the JupyterLab UI, open File -> New Launcher, and select a Python 3 Notebook.
+
+Click "OPEN JUPYTERLAB" to open JupyterLab UI.
+
+### Set-up environment
+In the JupyterLab UI, open File -> New Launcher, and select a Terminal.
+since service accounts not yet supported run following command to init gcloud with your email
+```bash
+gcloud init --console-only
+```
+select `[2] Log in with a new account` and follow instructions
+
+### Run examples 
+
+In the JupyterLab UI, open File -> New Launcher, and select a Python 3 Notebook.
 
 Then run the following to import the Git repo containing the ML notebooks/code. This will clone the codelab code to your JupyterLab environment.
 
@@ -34,4 +51,4 @@ Then run the following to import the Git repo containing the ML notebooks/code. 
 
 Then, navigate to */healthcare/imaging/ml/ml_codelab* in a left navigation bar of the JupyterLab UI.
 
-Then, click one of the one codelabs (.ipynb files) to begin.
+Then click one of the two(.ipynb files) to begin.

--- a/imaging/ml/ml_codelab/breast_density_auto_ml.ipynb
+++ b/imaging/ml/ml_codelab/breast_density_auto_ml.ipynb
@@ -65,41 +65,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "4WiSDYeS3faP"
-   },
-   "source": [
-    "### Store TCIA Dataset in Cloud Healthcare API\n",
-    "\n",
-    "The [TCIA REST API ](https://wiki.cancerimagingarchive.net/display/Public/TCIA+Programmatic+Interface+%28REST+API%29+Usage+Guide)  will be used to fetch the images. The TCIA requires an API key which can be retreived by following the instructions in the **Getting Started with the TCIA API** section of the previous link. Once you receive the API key, assign it below (**NOTE: TCIA does not support self-registration, so expect some turn-around time until you get the key**). "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "LjzzbUQOc5l0"
-   },
-   "outputs": [],
-   "source": [
-    "tcia_api_key = \"MY_KEY\" #@param"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "mhL5x08vYdy9"
-   },
-   "source": [
-    "We need to create a Cloud Healthcare API Dataset and Dicom Store to store the the DICOM instances sourced from TCIA. Please refer [here](https://cloud.google.com/healthcare/docs/introduction) for a description of the Cloud Healthcare API data hierarchy. Add your parameters for Cloud Healthcare API below:"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -111,105 +76,8 @@
    "source": [
     "project_id = \"MY_PROJECT\" # @param\n",
     "location = \"us-central1\" # @param\n",
-    "dataset_id = \"MY_DATASET\" # @param\n",
-    "dicom_store_id = \"MY_DICOM_STORE\" # @param\n",
-    "\n",
     "# Input data used by AutoML must be in a bucket with the following format.\n",
     "automl_bucket_name = \"gs://\" + project_id + \"-vcm\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "vgBA16ptbacM"
-   },
-   "outputs": [],
-   "source": [
-    "import json\n",
-    "import httplib2\n",
-    "import os\n",
-    "from oauth2client.client import GoogleCredentials\n",
-    "\n",
-    "# Path to Cloud Healthcare API.\n",
-    "HEALTHCARE_API_URL = 'https://healthcare.googleapis.com/v1beta1'\n",
-    "\n",
-    "http = httplib2.Http()\n",
-    "http = GoogleCredentials.get_application_default().authorize(http)\n",
-    "\n",
-    "# Create Cloud Healthcare API dataset.\n",
-    "path = os.path.join(HEALTHCARE_API_URL, 'projects', project_id, 'locations', location, 'datasets?dataset_id=' + dataset_id)\n",
-    "headers = {'Content-Type': 'application/json'}\n",
-    "resp, content = http.request(path, method='POST', headers=headers)\n",
-    "assert resp.status == 200, 'error creating Dataset, code: {0}, response: {1}'.format(resp.status, content)\n",
-    "print('Full response:\\n{0}'.format(content))\n",
-    "\n",
-    "# Create Cloud Healthcare API DICOM store.\n",
-    "path = os.path.join(HEALTHCARE_API_URL, 'projects', project_id, 'locations', location, 'datasets', dataset_id, 'dicomStores?dicom_store_id=' + dicom_store_id)\n",
-    "resp, content = http.request(path, method='POST', headers=headers)\n",
-    "assert resp.status == 200, 'error creating DICOM store, code: {0}, response: {1}'.format(resp.status, content)\n",
-    "print('Full response:\\n{0}'.format(content))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "HKsCfbXorosM"
-   },
-   "source": [
-    "Next, we are going to transfer the DICOM instances from the TCIA API to the Cloud Healthcare API. We have added a helper script called *[store_tcia_in_hc_api.py](./scripts/store_tcia_in_hc_api.py)* to do this. Internally, this uses the STOW-RS DICOMWeb protocol (implemented as DicomWebPost in Cloud Healthcare API).\n",
-    "\n",
-    "Note: We are transfering >100GB of data so this will take some time to complete (this takes ~30min on n1-standard-4 machine-type). There is an optional *--max_concurrency* flag that allows you to modify the rate of data transfer)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "shhPzNFArpHH"
-   },
-   "outputs": [],
-   "source": [
-    "# Store DICOM instances in Cloud Healthcare API.\n",
-    "!python -m scripts.store_tcia_in_hc_api --project_id=$project_id --location=$location --dataset_id=$dataset_id --dicom_store_id=$dicom_store_id --tcia_api_key=$tcia_api_key"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "mjFm5w356Z6t"
-   },
-   "source": [
-    "### Explore the Cloud Healthcare DICOM dataset (optional)\n",
-    "\n",
-    "This is an optional section to explore the Cloud Healthcare DICOM dataset. In the following code, we simply just list the studies that we have loaded into the Cloud Healthcare API. You can modify the *num_of_studies_to_print* parameter to print as many studies as desired."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "RUjYgoym7MZN"
-   },
-   "outputs": [],
-   "source": [
-    "num_of_studies_to_print = 2 # @param\n",
-    "\n",
-    "\n",
-    "path = os.path.join(HEALTHCARE_API_URL, 'projects', project_id, 'locations', location, 'datasets', dataset_id, 'dicomStores', dicom_store_id, 'dicomWeb', 'studies')\n",
-    "resp, content = http.request(path, method='GET')\n",
-    "assert resp.status == 200, 'error querying Dataset, code: {0}, response: {1}'.format(resp.status, content)\n",
-    "response = json.loads(content.decode())\n",
-    "\n",
-    "print(json.dumps(response[:num_of_studies_to_print], indent=2))"
    ]
   },
   {
@@ -267,7 +135,7 @@
     "id": "aIfKnxqHjE9A"
    },
    "source": [
-    "Next we will convert the DICOMs to JPEGs using the ExportDicomData API. This is an asynchronous call that returns an Operation name. You can use the Operation name to poll the status of the operation."
+    "Next we will convert the DICOMs to JPEGs using the [ExportDicomData](https://cloud.google.com/sdk/gcloud/reference/beta/healthcare/dicom-stores/export/gcs). "
    ]
   },
   {
@@ -280,24 +148,8 @@
    },
    "outputs": [],
    "source": [
-    "# Path to export DICOM data.\n",
-    "dicom_store_url = os.path.join(HEALTHCARE_API_URL, 'projects', project_id, 'locations', location, 'datasets', dataset_id, 'dicomStores', dicom_store_id)\n",
-    "path = dicom_store_url + \":export\"\n",
-    "\n",
-    "# Headers (send request in JSON format).\n",
-    "headers = {'Content-Type': 'application/json'}\n",
-    "\n",
-    "# Body (encoded in JSON format).\n",
-    "output_config = {'output_config': {'gcs_destination': {'uri_prefix': jpeg_folder, 'mime_type': 'image/jpeg; transfer-syntax=1.2.840.10008.1.2.4.50'}}}\n",
-    "body = json.dumps(output_config)\n",
-    "\n",
-    "resp, content = http.request(path, method='POST', headers=headers, body=body)\n",
-    "assert resp.status == 200, 'error exporting to JPEG, code: {0}, response: {1}'.format(resp.status, content)\n",
-    "print('Full response:\\n{0}'.format(content.decode()))\n",
-    "\n",
-    "# Record operation_name so we can poll for it later.\n",
-    "response = json.loads(content.decode())\n",
-    "operation_name = response['name']"
+    "%%bash -s {jpeg_folder}\n",
+    "gcloud beta healthcare --project chc-tcia  dicom-stores export gcs cbis-ddsm --location=us-central1 --dataset=cbis-ddsm --mime-type=\"image/jpeg; transfer-syntax=1.2.840.10008.1.2.4.50\" --gcs-uri-prefix=$1"
    ]
   },
   {
@@ -307,44 +159,7 @@
     "id": "pVhp8IdVkVH3"
    },
    "source": [
-    "We will use the Operation ID returned from the previous command to poll the status of ExportDicomData. This will take a few minutes to complete so we will wait until completion. When the operation is complete, the operation's *done* field will be set to true.\n",
-    "\n",
     "Meanwhile, you should be able to observe the JPEG images being added to your Google Cloud Storage bucket."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "G4GE7pzsl-lP"
-   },
-   "outputs": [],
-   "source": [
-    "import time\n",
-    "\n",
-    "def wait_for_operation_completion(path, timeout): \n",
-    "  success = False\n",
-    "  while time.time() < timeout:\n",
-    "    print('Waiting for operation completion...')\n",
-    "    resp, content = http.request(path, method='GET')\n",
-    "    assert resp.status == 200, 'error polling for Operation results, code: {0}, response: {1}'.format(resp.status, content)\n",
-    "    response = json.loads(content.decode())\n",
-    "    if 'done' in response:\n",
-    "      if response['done'] == True and 'error' not in response:\n",
-    "        success = True;\n",
-    "      break\n",
-    "    time.sleep(30)\n",
-    "\n",
-    "  print('Full response:\\n{0}'.format(content))      \n",
-    "  assert success, \"operation did not complete successfully in time limit\"\n",
-    "  print('Success!')\n",
-    "  return response\n",
-    "  \n",
-    "timeout = time.time() + 10*60 # Wait up to 10 minutes.\n",
-    "path = os.path.join(HEALTHCARE_API_URL, operation_name)\n",
-    "_ = wait_for_operation_completion(path, timeout)"
    ]
   },
   {
@@ -436,6 +251,17 @@
    },
    "outputs": [],
    "source": [
+    "import json\n",
+    "import httplib2\n",
+    "import os\n",
+    "from oauth2client.client import GoogleCredentials\n",
+    "\n",
+    "# Path to Cloud Healthcare API.\n",
+    "HEALTHCARE_API_URL = 'https://healthcare.googleapis.com/v1beta1'\n",
+    "\n",
+    "http = httplib2.Http()\n",
+    "http = GoogleCredentials.get_application_default().authorize(http)\n",
+    "\n",
     "# Path to AutoML API.\n",
     "AUTOML_API_URL = 'https://automl.googleapis.com/v1beta1'\n",
     "\n",
@@ -514,6 +340,26 @@
    },
    "outputs": [],
    "source": [
+    "import time\n",
+    "\n",
+    "def wait_for_operation_completion(path, timeout): \n",
+    "  success = False\n",
+    "  while time.time() < timeout:\n",
+    "    print('Waiting for operation completion...')\n",
+    "    resp, content = http.request(path, method='GET')\n",
+    "    assert resp.status == 200, 'error polling for Operation results, code: {0}, response: {1}'.format(resp.status, content)\n",
+    "    response = json.loads(content.decode())\n",
+    "    if 'done' in response:\n",
+    "      if response['done'] == True and 'error' not in response:\n",
+    "        success = True;\n",
+    "      break\n",
+    "    time.sleep(30)\n",
+    "\n",
+    "  print('Full response:\\n{0}'.format(content.decode()))      \n",
+    "  assert success, \"operation did not complete successfully in time limit\"\n",
+    "  print('Success!')\n",
+    "  return response\n",
+    "\n",
     "path = os.path.join(AUTOML_API_URL, operation_name)\n",
     "timeout = time.time() + 10*60 # Wait up to 10 minutes.\n",
     "_ = wait_for_operation_completion(path, timeout)"
@@ -700,6 +546,7 @@
    "outputs": [],
    "source": [
     "# Pubsub config.\n",
+    "dataset_id = \"MY_DATASET\"\n",
     "pubsub_topic_id = \"MY_PUBSUB_TOPIC_ID\" # @param\n",
     "pubsub_subscription_id = \"MY_PUBSUB_SUBSRIPTION_ID\" # @param\n",
     "\n",
@@ -708,6 +555,22 @@
     "\n",
     "pubsub_subscription_name = \"projects/\" + project_id + \"/subscriptions/\" + pubsub_subscription_id\n",
     "inference_dicom_store_name = \"projects/\" + project_id + \"/locations/\" + location + \"/datasets/\" + dataset_id + \"/dicomStores/\" + inference_dicom_store_id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "http = httplib2.Http()\n",
+    "http = GoogleCredentials.get_application_default().authorize(http)\n",
+    "# Create Cloud Healthcare API dataset.\n",
+    "path = os.path.join(HEALTHCARE_API_URL, 'projects', project_id, 'locations', location, 'datasets?dataset_id=' + dataset_id)\n",
+    "headers = {'Content-Type': 'application/json'}\n",
+    "resp, content = http.request(path, method='POST', headers=headers)\n",
+    "assert resp.status == 200, 'error creating Dataset, code: {0}, response: {1}'.format(resp.status, content)\n",
+    "print('Full response:\\n{0}'.format(content))"
    ]
   },
   {
@@ -848,7 +711,8 @@
    "source": [
     "# DICOM Study/Series UID of input mammography image that we'll push for inference.\n",
     "input_mammo_study_uid = \"1.3.6.1.4.1.9590.100.1.2.85935434310203356712688695661986996009\"\n",
-    "input_mammo_series_uid = \"1.3.6.1.4.1.9590.100.1.2.374115997511889073021386151921807063992\""
+    "input_mammo_series_uid = \"1.3.6.1.4.1.9590.100.1.2.374115997511889073021386151921807063992\"\n",
+    "input_mammo_instance_uid = \"1.3.6.1.4.1.9590.100.1.2.289923739312470966435676008311959891294\""
    ]
   },
   {
@@ -861,9 +725,14 @@
    },
    "outputs": [],
    "source": [
-    "%%bash -s {project_id} {location} {dataset_id} {inference_dicom_store_id} {tcia_api_key} {input_mammo_study_uid}\n",
-    "# Store input mammo image into Cloud Healthcare DICOMWeb API.\n",
-    "python -m scripts.store_tcia_in_hc_api --project_id=$1 --location=$2 --dataset_id=$3 --dicom_store_id=$4 --tcia_api_key=$5 --has_study_uid=$6"
+    "http = httplib2.Http()\n",
+    "http = GoogleCredentials.get_application_default().authorize(http)\n",
+    "chc_tcia_path = \"projects/chc-tcia/locations/us-central1/datasets/cbis-ddsm/dicomStores/cbis-ddsm\"\n",
+    "path = os.path.join(HEALTHCARE_API_URL, chc_tcia_path, 'dicomWeb', 'studies', input_mammo_study_uid, 'series', input_mammo_series_uid, 'instances', input_mammo_instance_uid)\n",
+    "resp, content = http.request(path, method='GET', headers={'Accept': 'application/dicom; transfer-syntax=*'})\n",
+    "path = os.path.join(HEALTHCARE_API_URL, inference_dicom_store_name, 'dicomWeb', 'studies')\n",
+    "headers = {'Content-Type': 'application/dicom'}\n",
+    "http.request(path, method='POST', headers=headers, body=content)"
    ]
   },
   {

--- a/imaging/ml/ml_codelab/breast_density_cloud_ml.ipynb
+++ b/imaging/ml/ml_codelab/breast_density_cloud_ml.ipynb
@@ -66,59 +66,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "ESGbpIVi3SO-"
-   },
-   "source": [
-    "### Store TCIA Dataset in Cloud Healthcare API\n",
-    "\n",
-    "The [TCIA REST API ](https://wiki.cancerimagingarchive.net/display/Public/TCIA+Programmatic+Interface+%28REST+API%29+Usage+Guide)  will be used to fetch the images. The TCIA requires an API key which can be retreived by following the instructions in the **Getting Started with the TCIA API** section of the previous link. Once you receive the API key, assign it below (**NOTE: TCIA does not support self-registration, so expect some turn-around time until you get the key**). "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "LjzzbUQOc5l0"
-   },
-   "outputs": [],
-   "source": [
-    "tcia_api_key = \"MY_KEY\" #@param"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "mhL5x08vYdy9"
-   },
-   "source": [
-    "We need to create a Cloud Healthcare API Dataset and Dicom Store to store the the DICOM instances sourced from TCIA. Please refer [here](https://cloud.google.com/healthcare/docs/introduction) for a description of the Cloud Healthcare API data hierarchy. Add your parameters for Cloud Healthcare API below:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "NSr5StGBZkYd"
-   },
-   "outputs": [],
-   "source": [
-    "project_id = \"MY_PROJECT\" # @param\n",
-    "location = \"us-central1\" # @param\n",
-    "dataset_id = \"MY_DATASET\" # @param\n",
-    "dicom_store_id = \"MY_DICOM_STORE\" # @param",
-    "\n",
-    "cloud_bucket_name = \"gs://\" + project_id + \"-vcm\""
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -128,88 +75,10 @@
    },
    "outputs": [],
    "source": [
-    "import json\n",
-    "import httplib2\n",
-    "import os\n",
-    "from oauth2client.client import GoogleCredentials\n",
-    "\n",
-    "# Path to Cloud Healthcare API.\n",
-    "HEALTHCARE_API_URL = 'https://healthcare.googleapis.com/v1beta1'\n",
-    "\n",
-    "http = httplib2.Http()\n",
-    "http = GoogleCredentials.get_application_default().authorize(http)\n",
-    "\n",
-    "# Create Cloud Healthcare API dataset.\n",
-    "path = os.path.join(HEALTHCARE_API_URL, 'projects', project_id, 'locations', location, 'datasets?dataset_id=' + dataset_id)\n",
-    "headers = {'Content-Type': 'application/json'}\n",
-    "resp, content = http.request(path, method='POST', headers=headers)\n",
-    "assert resp.status == 200, 'error creating Dataset, code: {0}, response: {1}'.format(resp.status, content)\n",
-    "print('Full response:\\n{0}'.format(content))\n",
-    "\n",
-    "# Create Cloud Healthcare API DICOM store.\n",
-    "path = os.path.join(HEALTHCARE_API_URL, 'projects', project_id, 'locations', location, 'datasets', dataset_id, 'dicomStores?dicom_store_id=' + dicom_store_id)\n",
-    "resp, content = http.request(path, method='POST', headers=headers)\n",
-    "assert resp.status == 200, 'error creating DICOM store, code: {0}, response: {1}'.format(resp.status, content)\n",
-    "print('Full response:\\n{0}'.format(content))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "HKsCfbXorosM"
-   },
-   "source": [
-    "Next, we are going to transfer the DICOM instances from the TCIA API to the Cloud Healthcare API. We have added a helper script called *[store_tcia_in_hc_api.py](./scripts/store_tcia_in_hc_api.py)* to do this. Internally, this uses the STOW-RS DICOMWeb protocol (implemented as DicomWebPost in Cloud Healthcare API).\n",
-    "\n",
-    "Note: We are transfering >100GB of data so this will take some time to complete (this takes ~30min on n1-standard-4 machine-type). There is an optional *--max_concurrency* flag that allows you to modify the rate of data transfer)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "shhPzNFArpHH"
-   },
-   "outputs": [],
-   "source": [
-    "# Store DICOM instances in Cloud Healthcare API.\n",
-    "!python -m scripts.store_tcia_in_hc_api --project_id=$project_id --location=$location --dataset_id=$dataset_id --dicom_store_id=$dicom_store_id --tcia_api_key=$tcia_api_key"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "u6i0JcRv7p3F"
-   },
-   "source": [
-    "### Explore the Cloud Healthcare DICOM dataset (optional)\n",
-    "\n",
-    "This is an optional section to explore the Cloud Healthcare DICOM dataset. In the following code, we simply just list the studies that we have loaded into the Cloud Healthcare API. You can modify the *num_of_studies_to_print* parameter to print as many studies as desired."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "SYZggK5-7vfM"
-   },
-   "outputs": [],
-   "source": [
-    "num_of_studies_to_print = 2 # @param\n",
-    "\n",
-    "\n",
-    "path = os.path.join(HEALTHCARE_API_URL, 'projects', project_id, 'locations', location, 'datasets', dataset_id, 'dicomStores', dicom_store_id, 'dicomWeb', 'studies')\n",
-    "resp, content = http.request(path, method='GET')\n",
-    "assert resp.status == 200, 'error querying Dataset, code: {0}, response: {1}'.format(resp.status, content)\n",
-    "response = json.loads(content.decode())\n",
-    "\n",
-    "print(json.dumps(response[:num_of_studies_to_print], indent=2))"
+    "project_id = \"MY_PROJECT\" # @param\n",
+    "location = \"us-central1\" # @param\n",
+    "# Input data used by Cloud ML must be in a bucket with the following format.\n",
+    "cloud_bucket_name = \"gs://\" + project_id + \"-vcm\""
    ]
   },
   {
@@ -266,7 +135,7 @@
     "id": "aIfKnxqHjE9A"
    },
    "source": [
-    "Next we will convert the DICOMs to JPEGs using the ExportDicomData API. This is an asynchronous call that returns an Operation name. The operation name will be used to poll the status of the operation."
+    "Next we will convert the DICOMs to JPEGs using the [ExportDicomData](https://cloud.google.com/sdk/gcloud/reference/beta/healthcare/dicom-stores/export/gcs). "
    ]
   },
   {
@@ -279,26 +148,8 @@
    },
    "outputs": [],
    "source": [
-    "# Path to request ExportDicomData operation.\n",
-    "dataset_url = os.path.join(HEALTHCARE_API_URL, 'projects', project_id, 'locations', location, 'datasets', dataset_id)\n",
-    "dicom_store_url = os.path.join(dataset_url, 'dicomStores', dicom_store_id)\n",
-    "path = dicom_store_url + \":export\"\n",
-    "\n",
-    "# Headers (send request in JSON format).\n",
-    "headers = {'Content-Type': 'application/json'}\n",
-    "\n",
-    "# Body (encoded in JSON format).\n",
-    "output_config = {'output_config': {'gcs_destination': {'uri_prefix': jpeg_bucket, 'mime_type': 'image/jpeg; transfer-syntax=1.2.840.10008.1.2.4.50'}}}\n",
-    "body = json.dumps(output_config)\n",
-    "\n",
-    "print(body)\n",
-    "resp, content = http.request(path, method='POST', headers=headers, body=body)\n",
-    "assert resp.status == 200, 'error exporting to JPEG, code: {0}, response: {1}'.format(resp.status, content)\n",
-    "print('Full response:\\n{0}'.format(content.decode()))\n",
-    "\n",
-    "# Record operation_name so we can poll for it later.\n",
-    "response = json.loads(content.decode())\n",
-    "operation_name = response['name']"
+    "%%bash -s {jpeg_bucket}\n",
+    "gcloud beta healthcare --project chc-tcia  dicom-stores export gcs cbis-ddsm --location=us-central1 --dataset=cbis-ddsm --mime-type=\"image/jpeg; transfer-syntax=1.2.840.10008.1.2.4.50\" --gcs-uri-prefix=$1"
    ]
   },
   {
@@ -311,41 +162,6 @@
     "We will use the Operation name returned from the previous command to poll the status of ExportDicomData. We will poll for operation completeness, which should take a few minutes. When the operation is complete, the operation's *done* field will be set to true.\n",
     "\n",
     "Meanwhile, you should be able to observe the JPEG images being added to your Google Cloud Storage bucket."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "G4GE7pzsl-lP"
-   },
-   "outputs": [],
-   "source": [
-    "import time\n",
-    "\n",
-    "def wait_for_operation_completion(path, timeout): \n",
-    "  success = False\n",
-    "  while time.time() < timeout:\n",
-    "    print('Waiting for operation completion...')\n",
-    "    resp, content = http.request(path, method='GET')\n",
-    "    assert resp.status == 200, 'error polling for Operation results, code: {0}, response: {1}'.format(resp.status, content)\n",
-    "    response = json.loads(content.decode())\n",
-    "    if 'done' in response:\n",
-    "      if response['done'] == True and 'error' not in response:\n",
-    "        success = True;\n",
-    "      break\n",
-    "    time.sleep(30)\n",
-    "\n",
-    "  print('Full response:\\n{0}'.format(content.decode()))      \n",
-    "  assert success, \"operation did not complete successfully in time limit\"\n",
-    "  print('Success!')\n",
-    "  return response\n",
-    "  \n",
-    "timeout = time.time() + 10*60 # Wait up to 10 minutes.\n",
-    "path = os.path.join(HEALTHCARE_API_URL, operation_name)\n",
-    "_ = wait_for_operation_completion(path, timeout)"
    ]
   },
   {
@@ -432,8 +248,7 @@
     "%%bash -s {project_id} {jpeg_bucket} {bottleneck_bucket} {validation_percentage} {testing_percentage} {dataflow_num_workers} {staging_bucket}\n",
     "\n",
     "# Install Python library dependencies.\n",
-    "sudo pip3 -q install apache_beam\n",
-    "\n",
+    "sudo pip3 install google-apitools apache_beam apache_beam[gcp]\n",
     "# Start job in Cloud Dataflow and wait for completion.\n",
     "python3 -m scripts.preprocess.preprocess \\\n",
     "    --project $1 \\\n",
@@ -505,7 +320,7 @@
     "%%bash -s {location} {bottleneck_bucket} {staging_bucket} {training_steps} {learning_rate} {exported_model_versioned_uri}\n",
     "\n",
     "# Start training on CMLE.\n",
-    "gcloud ml-engine jobs submit training breast_density \\\n",
+    "gcloud ai-platform jobs submit training breast_density \\\n",
     "    --python-version 3.5 \\\n",
     "    --runtime-version 1.14 \\\n",
     "    --scale-tier BASIC_GPU \\\n",
@@ -658,6 +473,7 @@
    "outputs": [],
    "source": [
     "# Pubsub config.\n",
+    "dataset_id = \"MY_DATASET\"\n",
     "pubsub_topic_id = \"MY_PUBSUB_TOPIC_ID\" # @param\n",
     "pubsub_subscription_id = \"MY_PUBSUB_SUBSRIPTION_ID\" # @param\n",
     "\n",
@@ -666,6 +482,22 @@
     "\n",
     "pubsub_subscription_name = \"projects/\" + project_id + \"/subscriptions/\" + pubsub_subscription_id\n",
     "inference_dicom_store_name = \"projects/\" + project_id + \"/locations/\" + location + \"/datasets/\" + dataset_id + \"/dicomStores/\" + inference_dicom_store_id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "http = httplib2.Http()\n",
+    "http = GoogleCredentials.get_application_default().authorize(http)\n",
+    "# Create Cloud Healthcare API dataset.\n",
+    "path = os.path.join(HEALTHCARE_API_URL, 'projects', project_id, 'locations', location, 'datasets?dataset_id=' + dataset_id)\n",
+    "headers = {'Content-Type': 'application/json'}\n",
+    "resp, content = http.request(path, method='POST', headers=headers)\n",
+    "assert resp.status == 200, 'error creating Dataset, code: {0}, response: {1}'.format(resp.status, content)\n",
+    "print('Full response:\\n{0}'.format(content))"
    ]
   },
   {
@@ -804,9 +636,10 @@
    },
    "outputs": [],
    "source": [
-    "# DICOM study and series UID of input mammography image that we'll push for inference.\n",
+    "# DICOM Study/Series UID of input mammography image that we'll push for inference.\n",
     "input_mammo_study_uid = \"1.3.6.1.4.1.9590.100.1.2.85935434310203356712688695661986996009\"\n",
-    "input_mammo_series_uid = \"1.3.6.1.4.1.9590.100.1.2.374115997511889073021386151921807063992\""
+    "input_mammo_series_uid = \"1.3.6.1.4.1.9590.100.1.2.374115997511889073021386151921807063992\"\n",
+    "input_mammo_instance_uid = \"1.3.6.1.4.1.9590.100.1.2.289923739312470966435676008311959891294\""
    ]
   },
   {
@@ -819,9 +652,14 @@
    },
    "outputs": [],
    "source": [
-    "%%bash -s {project_id} {location} {dataset_id} {inference_dicom_store_id} {tcia_api_key} {input_mammo_study_uid}\n",
-    "# Store input mammo image into Cloud Healthcare DICOMWeb API.\n",
-    "python -m scripts.store_tcia_in_hc_api --project_id=$1 --location=$2 --dataset_id=$3 --dicom_store_id=$4 --tcia_api_key=$5 --has_study_uid=$6"
+    "http = httplib2.Http()\n",
+    "http = GoogleCredentials.get_application_default().authorize(http)\n",
+    "chc_tcia_path = \"projects/chc-tcia/locations/us-central1/datasets/cbis-ddsm/dicomStores/cbis-ddsm\"\n",
+    "path = os.path.join(HEALTHCARE_API_URL, chc_tcia_path, 'dicomWeb', 'studies', input_mammo_study_uid, 'series', input_mammo_series_uid, 'instances', input_mammo_instance_uid)\n",
+    "resp, content = http.request(path, method='GET', headers={'Accept': 'application/dicom; transfer-syntax=*'})\n",
+    "path = os.path.join(HEALTHCARE_API_URL, inference_dicom_store_name, 'dicomWeb', 'studies')\n",
+    "headers = {'Content-Type': 'application/dicom'}\n",
+    "http.request(path, method='POST', headers=headers, body=content)"
    ]
   },
   {

--- a/imaging/ml/ml_codelab/scripts/preprocess/preprocess.py
+++ b/imaging/ml/ml_codelab/scripts/preprocess/preprocess.py
@@ -195,7 +195,7 @@ def _get_study_uid_to_image_path_map(input_path):
   study_uid_to_file_paths = {}
   for path in path_list:
     split_path = path.split('/')
-    study_uid_to_file_paths[split_path[3]] = path
+    study_uid_to_file_paths[split_path[4]] = path
   return study_uid_to_file_paths
 
 


### PR DESCRIPTION
based on https://github.com/GoogleCloudPlatform/healthcare/pull/423

- switch from gcs storage to hcapi hosted data - **done**
- remove redundant TCIA api code - **done**
- `gcloud beta healthcare dicom-stores export` instead of api call - **done**
- should be exported only train images that label breast density 2 or 3, avoid filter blacklisted dicoms - actually filtering already performed by https://github.com/GoogleCloudPlatform/healthcare/blob/master/imaging/ml/ml_codelab/scripts/tcia_utils.py#L77 and https://github.com/GoogleCloudPlatform/healthcare/blob/master/imaging/ml/ml_codelab/scripts/tcia_utils.py#L81

not yet resolved: access to https://healthcare.googleapis.com/v1beta1/projects/chc-tcia/locations/us-central1/datasets/cbis-ddsm/dicomStores/cbis-ddsm seems to be managed by CHC-API team https://github.com/GoogleCloudPlatform/healthcare/issues/433#issuecomment-576373726