### PR TITLE
Update path constructor for fhir resources

### DIFF
--- a/fhir/immunizations_demo/docs/README.md
+++ b/fhir/immunizations_demo/docs/README.md
@@ -267,8 +267,7 @@ how the `Immunization` class is implemented.
  */
 async createResource<R extends fhir.Resource>(resource: R): Promise<R> {
   const resourceType = getResourceType(resource);
-  const resourceUrl =
-      this.FHIR_STORE_URL + encodeURL`resources/${resourceType}`;
+  const resourceUrl = this.FHIR_STORE_URL + encodeURL`fhir/${resourceType}`;
   return this.performRequest<R>({
     path: resourceUrl,
     method: 'POST',
@@ -306,8 +305,8 @@ have to check what the reaction's server-assigned ID is.
 async saveResource<R extends fhir.Resource>(resource: R): Promise<R> {
   const resourceType = getResourceType(resource);
   const resourceID = getResourceID(resource);
-  const resourceUrl = this.FHIR_STORE_URL +
-      encodeURL`resources/${resourceType}/${resourceID}`;
+  const resourceUrl =
+      this.FHIR_STORE_URL + encodeURL`fhir/${resourceType}/${resourceID}`;
   return this.performRequest<R>({
     path: resourceUrl,
     method: 'PUT',
@@ -356,12 +355,12 @@ async deleteResource<R extends fhir.Resource>(
     resourceID = getResourceID(resource);
   }
   this.performRequest({
-    path: this.FHIR_STORE_URL +
-        encodeURL`resources/${resourceType}/${resourceID}`,
+    path: this.FHIR_STORE_URL + encodeURL`fhir/${resourceType}/${resourceID}`,
     method: 'DELETE',
     headers: getFHIRHeaders(),
   });
 }
+
 
 // file: src/app/immunizations/immunization-form/immunization-form.component.ts
 /**
@@ -403,8 +402,7 @@ tells the FHIR store to also return any `QuestionnaireResponses` that have
 async searchResource(
     resourceType: string,
     queryParams?: {[key: string]: string}): Promise<fhir.Bundle> {
-  const resourceUrl =
-      this.FHIR_STORE_URL + encodeURL`resources/${resourceType}/`;
+  const resourceUrl = this.FHIR_STORE_URL + encodeURL`fhir/${resourceType}/`;
   return this.performRequest<fhir.Bundle>({
     path: resourceUrl,
     headers: getFHIRHeaders(),

--- a/fhir/immunizations_demo/inference/main.py
+++ b/fhir/immunizations_demo/inference/main.py
@@ -300,4 +300,4 @@ def _construct_resource_name(project_id, location, dataset_id, fhir_store_id,
   resource_id):
   """Constructs a resource name."""
   return '/'.join(['projects', project_id, 'locations', location, 'datasets',
-      dataset_id, 'fhirStores', fhir_store_id, 'resources', resource_id])
+      dataset_id, 'fhirStores', fhir_store_id, 'fhir', resource_id])


### PR DESCRIPTION
This cloud function was returning "resource not found" errors when trying to retrieve ../resources/Patient/... using v1beta1. Documentation references .../fhir/Patient/... as the location of the Patient record needed. Updating this path constructor eliminates the error and produces the expected results as observed in the function logs and the FHIR Immunizations web app.