### PR TITLE
Explicitly replace "import tensorflow" with "tensorflow.compat.v1" for TF2.x migration

### DIFF
--- a/fhir/immunizations_demo/models/trainer/model.py
+++ b/fhir/immunizations_demo/models/trainer/model.py
@@ -33,7 +33,7 @@ to finish data analysis and machine learning tasks. This problem
 itself is not a natural machine learning task.
 """
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 
 from functools import reduce
 

--- a/fhir/lung-cancer/models/trainer/model.py
+++ b/fhir/lung-cancer/models/trainer/model.py
@@ -30,7 +30,7 @@ itself is not a natural machine learning task.
 """
 
 import functools
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 
 # Input data specific flags.
 tf.flags.DEFINE_string(


### PR DESCRIPTION
Explicitly replace "import tensorflow" with "tensorflow.compat.v1" for TF2.x migration
