### PR TITLE
Fix generate_synthea_dataset.ipynb missing java 1.8

### DIFF
--- a/ml_solutions/generate_synthea_dataset.ipynb
+++ b/ml_solutions/generate_synthea_dataset.ipynb
@@ -267,7 +267,8 @@
       "outputs": [],
       "source": [
         "%%bash -s \"$staging_bucket_path\"\n",
-        "update-java-alternatives -s java-1.8.0-openjdk-amd64 \n",
+        "apt install openjdk-8-jdk\n",
+        "update-java-alternatives -s java-1.8.0-openjdk-amd64\n",
         "git clone https://github.com/GoogleCloudPlatform/bigquery-data-importer.git\n",
         "tar --create --gzip --file synmass.tar.gz output/csv\n",
         "gsutil cp synmass.tar.gz \"$1\""


### PR DESCRIPTION
By default, only java 1.11 is installed now, so update-java-alternatives fails on a missing option.

Now we install the version we want before trying to switch to it.