### PR TITLE
GCS to HDE GCS Utility

### DIFF
--- a/utilities/gcs_to_hde_gcs/README.md
+++ b/utilities/gcs_to_hde_gcs/README.md
@@ -1,0 +1,9 @@
+This utility provides a sample Beam pipeline to migrate data from a GCS bucket into an HDE GCS bucket. This is a common scenario as customers often use a GCS bucket as a Cloud landing zone, but need to migrate files from that landing zone into HDE (another GCS bucket).
+
+To use this utility:
+
+Copy paste the Beam pipeline migration code (make sure to run `pip install apache-beam[gcp]`), and modify to suit your needs for the migration.
+
+If you are able to upload your schema.json file into the Cloud Landig Zone GCS Bucket, use the gcloud commands in the utility to migrate the file into the HDE GCS bucket. Note here that the pipeline includes a specific GCS folder structure, necessary for the HDE GCS bucket.
+
+Write a blank file titled `START_PIPELINE` by using the start_pipeline Beam pipeline. Note here that the pipeline includes a specific GCS folder structure, necessary for the HDE GCS bucket.

--- a/utilities/gcs_to_hde_gcs/pipeline.py
+++ b/utilities/gcs_to_hde_gcs/pipeline.py
@@ -1,0 +1,29 @@
+import argparse
+
+import apache_beam as beam
+from apache_beam.options.pipeline_options import PipelineOptions
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--input-csv', default='gs://input-bucket-here')
+args, beam_args = parser.parse_known_args()
+
+# Create and set your Pipeline Options.
+beam_options = PipelineOptions(beam_args)
+
+
+def udf():
+    # Define custom CSV transformation logic here
+    yield
+
+with beam.Pipeline(options=beam_options) as pipeline:
+  p = (
+      pipeline
+      | beam.io.ReadFromText(args.input)
+      | beam.ParDo(udf())
+      | beam.io.WriteToText(args.input)
+  )
+
+# Note that the final WriteToText transformation in the pipeline would require Storage.object.delete permissions
+# in the pipeline on GCP, which may not be granted for business reasons. If this is the case, please write to
+# GCS using the API provided here:
+# https://github.com/googleapis/python-storage/blob/HEAD/samples/snippets/storage_fileio_write_read.py`)

--- a/utilities/gcs_to_hde_gcs/requirements.txt
+++ b/utilities/gcs_to_hde_gcs/requirements.txt
@@ -1,0 +1,3 @@
+apache-beam[gcp]==2.48.0
+argparse
+google

--- a/utilities/gcs_to_hde_gcs/schema_migration.MD
+++ b/utilities/gcs_to_hde_gcs/schema_migration.MD
@@ -1,0 +1,7 @@
+``` Use one of the following to migrate your schema.json file into the HDE GCS folder.```
+
+```gcloud storage cp gs://PREFIX-ENVIRONMENT-csv-input/CSV_DATA_SOURCE/CSV_DATA_SOURCE_{TIMESTAMP}/schemas/```
+
+OR
+
+```gcloud storage mv gs://SOURCE_BUCKET_NAME/SOURCE_OBJECT_NAME gs://PREFIX-ENVIRONMENT-csv-input/CSV_DATA_SOURCE/CSV_DATA_SOURCE_{TIMESTAMP}/schemas/```

--- a/utilities/gcs_to_hde_gcs/start_pipeline.py
+++ b/utilities/gcs_to_hde_gcs/start_pipeline.py
@@ -1,0 +1,15 @@
+import argparse
+import apache_beam as beam
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--start-pipeline-path', default= 'gs://PREFIX-ENVIRONMENT-csv-input/CSV_DATA_SOURCE/CSV_DATA_SOURCE_{TIMESTAMP}/START_PIPELINE')
+
+
+def udf():
+  file = io.gcsio.GcsIO().open(filename =gcs_path, mode = 'w', mime_type='application/csv')
+  yield
+
+with beam.Pipeline(options=beam_options) as pipeline:
+  p = (
+      pipeline | beam.ParDo(udf())
+  )


### PR DESCRIPTION
This utility helps users migrate CSV files from a Cloud landing GCS bucket into an HDE GCS bucket. This utility also provides a `start_pipeline` file write necessary for HDE, as well as a `schema.json` migration command that users can utilize.